### PR TITLE
feat(404): add Space Invaders game to 404 page

### DIFF
--- a/404.html
+++ b/404.html
@@ -20,6 +20,7 @@
       left: 0;
       width: 100%;
       height: 100%;
+      background: rgba(0, 0, 0, 0.7);
     }
     .message {
       position: absolute;
@@ -40,113 +41,529 @@
   <script>
     const canvas = document.getElementById('gameCanvas');
     const ctx = canvas.getContext('2d');
-    const paddleWidth = 10, paddleHeight = 80;
-    const puckRadius = 20, puckText = '404';
-    let leftPaddle = { x: 10, y: 0 };
-    let rightPaddle = { x: 0, y: 0 };
-    let puck = { x: 0, y: 0, vx: 4, vy: 4 };
-
+    
+    // Game states
+    const GAME_STATES = {
+      START: 'start',
+      PLAYING: 'playing',
+      GAME_OVER: 'game_over'
+    };
+    
+    let gameState = GAME_STATES.START;
+    let score = 0;
+    let lives = 3;
+    let level = 1;
+    
+    // Game objects
+    let player = {
+      x: 0,
+      y: 0,
+      width: 40,
+      height: 20,
+      speed: 5
+    };
+    
+    let invaders = [];
+    let playerBullets = [];
+    let enemyBullets = [];
+    let particles = [];
+    let ufo = null;
+    let animationFrame = 0;
+    
+    // Game settings
+    const INVADER_ROWS = 5;
+    const INVADER_COLS = 11;
+    const INVADER_WIDTH = 32;
+    const INVADER_HEIGHT = 24;
+    const INVADER_SPACING = 8;
+    const BULLET_SPEED = 6;
+    const MAX_PLAYER_BULLETS = 3;
+    const UFO_SPEED = 2;
+    
+    // Sprite patterns (using text for retro look)
+    const sprites = {
+      player: ['▲▲▲▲▲', '█████', '█████'],
+      invader1: ['  ▄▄  ', ' ████ ', '██████', '██▄▄██', '▄▄  ▄▄'],
+      invader2: [' ▄██▄ ', '██████', '███▄██', '██████', '▄▄██▄▄'],
+      invader3: ['▄████▄', '██████', '██▄▄██', ' ████ ', ' ▄██▄ '],
+      ufo: ['▄▄████▄▄', '████████', '▄██████▄', ' ▄▄▄▄▄▄ ']
+    };
+    
+    // Input handling
+    const keys = {};
+    let canShoot = true;
+    let shootCooldown = 0;
+    
+    window.addEventListener('keydown', (e) => {
+      keys[e.code] = true;
+      
+      if (e.code === 'Enter') {
+        if (gameState === GAME_STATES.START) {
+          startGame();
+        } else if (gameState === GAME_STATES.GAME_OVER) {
+          resetGame();
+        }
+      }
+      
+      if (e.code === 'Space' && gameState === GAME_STATES.PLAYING) {
+        shootPlayerBullet();
+        e.preventDefault();
+      }
+    });
+    
+    window.addEventListener('keyup', (e) => {
+      keys[e.code] = false;
+    });
+    
     function resize() {
-      const w = window.innerWidth;
-      const h = window.innerHeight;
-      canvas.width = w;
-      canvas.height = h;
-      leftPaddle.y = (h - paddleHeight) / 2;
-      rightPaddle.x = w - paddleWidth - 10;
-      rightPaddle.y = (h - paddleHeight) / 2;
-      puck.x = w / 2;
-      puck.y = h / 2;
-    }
-
-    function drawPaddle(p) {
-      ctx.fillStyle = '#fff';
-      ctx.fillRect(p.x, p.y, paddleWidth, paddleHeight);
-    }
-
-    function drawPuck() {
-      ctx.fillStyle = '#fff';
-      ctx.beginPath();
-      ctx.arc(puck.x, puck.y, puckRadius, 0, Math.PI * 2);
-      ctx.fill();
-      ctx.fillStyle = '#000';
-      ctx.font = '16px sans-serif';
-      ctx.textAlign = 'center';
-      ctx.textBaseline = 'middle';
-      ctx.fillText(puckText, puck.x, puck.y);
-    }
-
-    // Predict vertical intercept position accounting for bounces
-    function predictInterceptY(paddleX) {
-      const dx = paddleX - puck.x;
-      const t = dx / puck.vx;
-      if (t <= 0) return canvas.height / 2;
-      let y = puck.y + puck.vy * t;
-      const H = canvas.height;
-      // Reflect off top/bottom
-      while (y < 0 || y > H) {
-        if (y < 0) y = -y;
-        if (y > H) y = 2 * H - y;
+      canvas.width = window.innerWidth;
+      canvas.height = window.innerHeight;
+      
+      // Position player at bottom center
+      player.x = canvas.width / 2 - player.width / 2;
+      player.y = canvas.height - player.height - 30;
+      
+      // Initialize invaders if game is playing
+      if (gameState === GAME_STATES.PLAYING && invaders.length === 0) {
+        initInvaders();
       }
-      return y;
     }
-
+    
+    function startGame() {
+      gameState = GAME_STATES.PLAYING;
+      score = 0;
+      lives = 3;
+      level = 1;
+      playerBullets = [];
+      enemyBullets = [];
+      particles = [];
+      initInvaders();
+    }
+    
+    function resetGame() {
+      gameState = GAME_STATES.START;
+      invaders = [];
+      playerBullets = [];
+      enemyBullets = [];
+      particles = [];
+    }
+    
+    function initInvaders() {
+      invaders = [];
+      const startX = (canvas.width - (INVADER_COLS * (INVADER_WIDTH + INVADER_SPACING) - INVADER_SPACING)) / 2;
+      const startY = 100;
+      
+      for (let row = 0; row < INVADER_ROWS; row++) {
+        for (let col = 0; col < INVADER_COLS; col++) {
+          let invaderType;
+          let points;
+          if (row === 0) { invaderType = 3; points = 30; }
+          else if (row <= 2) { invaderType = 2; points = 20; }
+          else { invaderType = 1; points = 10; }
+          
+          invaders.push({
+            x: startX + col * (INVADER_WIDTH + INVADER_SPACING),
+            y: startY + row * (INVADER_HEIGHT + INVADER_SPACING),
+            width: INVADER_WIDTH,
+            height: INVADER_HEIGHT,
+            type: invaderType,
+            points: points,
+            alive: true,
+            animFrame: 0
+          });
+        }
+      }
+    }
+    
+    function spawnUFO() {
+      if (!ufo && Math.random() < 0.0008) { // Random UFO spawn
+        ufo = {
+          x: -100,
+          y: 50,
+          width: 64,
+          height: 32,
+          speed: UFO_SPEED,
+          points: 100 + Math.floor(Math.random() * 200), // 100-300 points
+          alive: true
+        };
+      }
+    }
+    
+    function shootPlayerBullet() {
+      if (playerBullets.length < MAX_PLAYER_BULLETS && canShoot) {
+        playerBullets.push({
+          x: player.x + player.width / 2 - 2,
+          y: player.y,
+          width: 4,
+          height: 10,
+          speed: -BULLET_SPEED
+        });
+        canShoot = false;
+        shootCooldown = 10;
+      }
+    }
+    
+    function updatePlayer() {
+      // Movement
+      if (keys['ArrowLeft'] && player.x > 0) {
+        player.x -= player.speed;
+      }
+      if (keys['ArrowRight'] && player.x < canvas.width - player.width) {
+        player.x += player.speed;
+      }
+      
+      // Shooting cooldown
+      if (shootCooldown > 0) {
+        shootCooldown--;
+        if (shootCooldown === 0) {
+          canShoot = true;
+        }
+      }
+    }
+    
+    function updateBullets() {
+      // Update player bullets
+      for (let i = playerBullets.length - 1; i >= 0; i--) {
+        const bullet = playerBullets[i];
+        bullet.y += bullet.speed;
+        
+        // Remove bullets that go off screen
+        if (bullet.y < 0) {
+          playerBullets.splice(i, 1);
+        }
+      }
+      
+      // Update enemy bullets
+      for (let i = enemyBullets.length - 1; i >= 0; i--) {
+        const bullet = enemyBullets[i];
+        bullet.y += bullet.speed;
+        
+        // Remove bullets that go off screen
+        if (bullet.y > canvas.height) {
+          enemyBullets.splice(i, 1);
+        }
+      }
+    }
+    
+    function updateInvaders() {
+      if (invaders.length === 0) return;
+      
+      let shouldMoveDown = false;
+      const aliveInvaders = invaders.filter(inv => inv.alive);
+      const speed = 0.5 + (level - 1) * 0.3 + (55 - aliveInvaders.length) * 0.05; // Speed increases as invaders die
+      
+      // Check if any invader hits the edge
+      for (const invader of invaders) {
+        if (!invader.alive) continue;
+        if ((invader.x <= 10 && invader.direction === -1) || 
+            (invader.x >= canvas.width - invader.width - 10 && invader.direction === 1)) {
+          shouldMoveDown = true;
+          break;
+        }
+      }
+      
+      // Move invaders
+      for (const invader of invaders) {
+        if (!invader.alive) continue;
+        
+        if (shouldMoveDown) {
+          invader.y += 16;
+          invader.direction = invader.direction || 1;
+          invader.direction *= -1;
+        } else {
+          invader.direction = invader.direction || 1;
+          invader.x += speed * invader.direction;
+        }
+        
+        // Update animation frame
+        invader.animFrame = Math.floor(animationFrame / 30) % 2;
+      }
+      
+      // More aggressive enemy shooting - multiple bullets
+      const shootChance = 0.004 + level * 0.002 + (55 - aliveInvaders.length) * 0.0001;
+      if (Math.random() < shootChance && aliveInvaders.length > 0) {
+        // Find bottom-most invaders in each column
+        const bottomInvaders = {};
+        for (const invader of aliveInvaders) {
+          const col = Math.floor((invader.x - aliveInvaders[0].x) / (INVADER_WIDTH + INVADER_SPACING));
+          if (!bottomInvaders[col] || invader.y > bottomInvaders[col].y) {
+            bottomInvaders[col] = invader;
+          }
+        }
+        
+        const shooters = Object.values(bottomInvaders);
+        const shooter = shooters[Math.floor(Math.random() * shooters.length)];
+        
+        enemyBullets.push({
+          x: shooter.x + shooter.width / 2 - 2,
+          y: shooter.y + shooter.height,
+          width: 3,
+          height: 8,
+          speed: BULLET_SPEED + Math.random() * 2
+        });
+      }
+    }
+    
+    function updateUFO() {
+      if (ufo) {
+        ufo.x += ufo.speed;
+        if (ufo.x > canvas.width + 100) {
+          ufo = null;
+        }
+      }
+    }
+    
+    function checkCollisions() {
+      // Player bullets vs invaders
+      for (let i = playerBullets.length - 1; i >= 0; i--) {
+        const bullet = playerBullets[i];
+        
+        for (const invader of invaders) {
+          if (!invader.alive) continue;
+          
+          if (bullet.x < invader.x + invader.width &&
+              bullet.x + bullet.width > invader.x &&
+              bullet.y < invader.y + invader.height &&
+              bullet.y + bullet.height > invader.y) {
+            
+            // Hit invader
+            invader.alive = false;
+            playerBullets.splice(i, 1);
+            score += invader.points;
+            
+            // Create explosion particles
+            createExplosion(invader.x + invader.width / 2, invader.y + invader.height / 2);
+            break;
+          }
+        }
+        
+        // Player bullets vs UFO
+        if (ufo && ufo.alive) {
+          if (bullet.x < ufo.x + ufo.width &&
+              bullet.x + bullet.width > ufo.x &&
+              bullet.y < ufo.y + ufo.height &&
+              bullet.y + bullet.height > ufo.y) {
+            
+            // Hit UFO
+            ufo.alive = false;
+            playerBullets.splice(i, 1);
+            score += ufo.points;
+            
+            // Create special explosion for UFO
+            createExplosion(ufo.x + ufo.width / 2, ufo.y + ufo.height / 2, true);
+            
+            // Show points briefly
+            setTimeout(() => { ufo = null; }, 1000);
+            break;
+          }
+        }
+      }
+      
+      // Enemy bullets vs player
+      for (let i = enemyBullets.length - 1; i >= 0; i--) {
+        const bullet = enemyBullets[i];
+        
+        if (bullet.x < player.x + player.width &&
+            bullet.x + bullet.width > player.x &&
+            bullet.y < player.y + player.height &&
+            bullet.y + bullet.height > player.y) {
+          
+          // Player hit
+          enemyBullets.splice(i, 1);
+          lives--;
+          createExplosion(player.x + player.width / 2, player.y + player.height / 2);
+          
+          if (lives <= 0) {
+            gameState = GAME_STATES.GAME_OVER;
+          }
+          break;
+        }
+      }
+      
+      // Check if all invaders destroyed
+      const aliveInvaders = invaders.filter(inv => inv.alive);
+      if (aliveInvaders.length === 0 && gameState === GAME_STATES.PLAYING) {
+        level++;
+        initInvaders();
+      }
+      
+      // Check if invaders reached player
+      for (const invader of invaders) {
+        if (invader.alive && invader.y + invader.height >= player.y) {
+          gameState = GAME_STATES.GAME_OVER;
+          break;
+        }
+      }
+    }
+    
+    function createExplosion(x, y, isUFO = false) {
+      const particleCount = isUFO ? 16 : 8;
+      const speed = isUFO ? 8 : 6;
+      const life = isUFO ? 40 : 30;
+      
+      for (let i = 0; i < particleCount; i++) {
+        particles.push({
+          x: x,
+          y: y,
+          vx: (Math.random() - 0.5) * speed,
+          vy: (Math.random() - 0.5) * speed,
+          life: life,
+          maxLife: life,
+          isUFO: isUFO
+        });
+      }
+    }
+    
+    function updateParticles() {
+      for (let i = particles.length - 1; i >= 0; i--) {
+        const particle = particles[i];
+        particle.x += particle.vx;
+        particle.y += particle.vy;
+        particle.life--;
+        
+        if (particle.life <= 0) {
+          particles.splice(i, 1);
+        }
+      }
+    }
+    
+    function drawSprite(sprite, x, y, color = '#ffffff', scale = 1) {
+      ctx.fillStyle = color;
+      ctx.font = `${12 * scale}px monospace`;
+      ctx.textAlign = 'left';
+      ctx.textBaseline = 'top';
+      
+      for (let i = 0; i < sprite.length; i++) {
+        ctx.fillText(sprite[i], x, y + i * 12 * scale);
+      }
+    }
+    
+    function drawPlayer() {
+      drawSprite(sprites.player, player.x, player.y, '#00ff00', 1);
+    }
+    
+    function drawInvaders() {
+      for (const invader of invaders) {
+        if (!invader.alive) continue;
+        
+        let spriteKey = `invader${invader.type}`;
+        let color;
+        
+        // Different colors for different types
+        if (invader.type === 3) color = '#ff0000';
+        else if (invader.type === 2) color = '#ffaa00';
+        else color = '#00ffff';
+        
+        drawSprite(sprites[spriteKey], invader.x, invader.y, color, 0.8);
+      }
+    }
+    
+    function drawUFO() {
+      if (ufo && ufo.alive) {
+        drawSprite(sprites.ufo, ufo.x, ufo.y, '#ff00ff', 1);
+      } else if (ufo && !ufo.alive) {
+        // Show points for destroyed UFO
+        ctx.fillStyle = '#ffff00';
+        ctx.font = '16px monospace';
+        ctx.textAlign = 'center';
+        ctx.fillText(`${ufo.points}`, ufo.x + ufo.width / 2, ufo.y + ufo.height / 2);
+      }
+    }
+    
+    function drawBullets() {
+      // Player bullets
+      ctx.fillStyle = '#ffffff';
+      for (const bullet of playerBullets) {
+        ctx.fillRect(bullet.x, bullet.y, bullet.width, bullet.height);
+      }
+      
+      // Enemy bullets
+      ctx.fillStyle = '#ff0000';
+      for (const bullet of enemyBullets) {
+        ctx.fillRect(bullet.x, bullet.y, bullet.width, bullet.height);
+      }
+    }
+    
+    function drawParticles() {
+      for (const particle of particles) {
+        const alpha = particle.life / particle.maxLife;
+        if (particle.isUFO) {
+          ctx.fillStyle = `rgba(255, 0, 255, ${alpha})`;
+        } else {
+          ctx.fillStyle = `rgba(255, 255, 0, ${alpha})`;
+        }
+        ctx.fillRect(particle.x - 2, particle.y - 2, 4, 4);
+      }
+    }
+    
+    function drawUI() {
+      ctx.fillStyle = '#ffffff';
+      ctx.font = '20px sans-serif';
+      ctx.textAlign = 'left';
+      
+      // Score
+      ctx.fillText(`Score: ${score}`, 20, canvas.height - 60);
+      
+      // Lives
+      ctx.fillText(`Lives: ${lives}`, 20, canvas.height - 30);
+      
+      // Level
+      ctx.fillText(`Level: ${level}`, canvas.width - 120, canvas.height - 30);
+      
+      if (gameState === GAME_STATES.START) {
+        ctx.textAlign = 'center';
+        ctx.font = '32px sans-serif';
+        ctx.fillText('SPACE INVADERS', canvas.width / 2, canvas.height / 2 - 100);
+        ctx.font = '20px sans-serif';
+        ctx.fillText('Press ENTER to Start', canvas.width / 2, canvas.height / 2 - 50);
+        ctx.fillText('Arrow Keys to Move, SPACE to Shoot', canvas.width / 2, canvas.height / 2 - 20);
+      } else if (gameState === GAME_STATES.GAME_OVER) {
+        ctx.textAlign = 'center';
+        ctx.font = '32px sans-serif';
+        ctx.fillText('GAME OVER', canvas.width / 2, canvas.height / 2 - 50);
+        ctx.font = '20px sans-serif';
+        ctx.fillText(`Final Score: ${score}`, canvas.width / 2, canvas.height / 2 - 10);
+        ctx.fillText('Press ENTER to Restart', canvas.width / 2, canvas.height / 2 + 20);
+      }
+    }
+    
     function update() {
-      // Move puck
-      puck.x += puck.vx;
-      puck.y += puck.vy;
-      // Wall bounce
-      if (puck.y - puckRadius < 0 || puck.y + puckRadius > canvas.height) {
-        puck.vy *= -1;
+      animationFrame++;
+      
+      if (gameState === GAME_STATES.PLAYING) {
+        updatePlayer();
+        updateBullets();
+        updateInvaders();
+        updateUFO();
+        spawnUFO();
+        checkCollisions();
+        updateParticles();
       }
-      // Paddle collision
-      if (puck.x - puckRadius < leftPaddle.x + paddleWidth &&
-          puck.y > leftPaddle.y && puck.y < leftPaddle.y + paddleHeight) {
-        puck.vx = Math.abs(puck.vx);
-      }
-      if (puck.x + puckRadius > rightPaddle.x &&
-          puck.y > rightPaddle.y && puck.y < rightPaddle.y + paddleHeight) {
-        puck.vx = -Math.abs(puck.vx);
-      }
-      // Reset
-      if (puck.x < 0 || puck.x > canvas.width) {
-        puck.x = canvas.width / 2;
-        puck.y = canvas.height / 2;
-        puck.vx = 4 * (Math.random() > 0.5 ? 1 : -1);
-        puck.vy = 4 * (Math.random() > 0.5 ? 1 : -1);
-      }
-      // AI movement
-      const speed = 3;
-      // Left paddle AI
-      const targetL = predictInterceptY(leftPaddle.x + paddleWidth);
-      if (targetL < leftPaddle.y + paddleHeight / 2 - 5) {
-        leftPaddle.y -= speed;
-      } else if (targetL > leftPaddle.y + paddleHeight / 2 + 5) {
-        leftPaddle.y += speed;
-      }
-      // Right paddle AI
-      const targetR = predictInterceptY(rightPaddle.x);
-      if (targetR < rightPaddle.y + paddleHeight / 2 - 5) {
-        rightPaddle.y -= speed;
-      } else if (targetR > rightPaddle.y + paddleHeight / 2 + 5) {
-        rightPaddle.y += speed;
-      }
-      // Constrain
-      leftPaddle.y = Math.max(0, Math.min(canvas.height - paddleHeight, leftPaddle.y));
-      rightPaddle.y = Math.max(0, Math.min(canvas.height - paddleHeight, rightPaddle.y));
     }
-
-    function loop() {
+    
+    function draw() {
       ctx.clearRect(0, 0, canvas.width, canvas.height);
-      drawPaddle(leftPaddle);
-      drawPuck();
-      drawPaddle(rightPaddle);
-      update();
-      requestAnimationFrame(loop);
+      
+      if (gameState === GAME_STATES.PLAYING) {
+        drawPlayer();
+        drawInvaders();
+        drawUFO();
+        drawBullets();
+        drawParticles();
+      }
+      
+      drawUI();
     }
-
+    
+    function gameLoop() {
+      update();
+      draw();
+      requestAnimationFrame(gameLoop);
+    }
+    
     window.addEventListener('resize', resize);
     resize();
-    loop();
+    gameLoop();
   </script>
 </body>
 </html>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,72 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Structure
+
+This repository contains two separate web applications:
+
+1. **Jekyll Site (Root)**: Academic website built with Jekyll/Ruby for publications and CV
+2. **React App (src/ directory)**: Modern SPA built with React/Vite for portfolio
+
+## Development Commands
+
+### Jekyll Site (Root)
+```bash
+# Install dependencies
+bundle install
+
+# Run development server
+bundle exec jekyll serve
+
+# Build for production
+bundle exec jekyll build
+```
+
+### React App (src/ directory)
+```bash
+cd src/
+
+# Install dependencies
+npm install
+
+# Development server
+npm run dev
+
+# Build for production
+npm run build
+
+# Lint code
+npm run lint
+
+# Deploy to GitHub Pages
+npm run deploy
+```
+
+## Architecture Overview
+
+### Jekyll Site Structure
+- **Publications**: Stored in `_publications/` as markdown files with frontmatter
+- **Layouts**: Custom layouts in `_layouts/` for different content types
+- **Assets**: Static files in `assets/` directory
+- **Configuration**: Site settings in `_config.yml`
+
+### React App Structure
+- **Components**: Reusable UI components in `src/components/`
+- **Styling**: SCSS modules in `src/assets/css/`
+- **Data**: JSON files for publications and profile data
+- **Routing**: React Router for SPA navigation
+
+## Publication Management
+
+- Publications are managed via PostgreSQL database
+- `add_publication.py`: GUI tool for adding new publications to database
+- `update_publications.py`: Generates markdown files from database for Jekyll site
+- Publications appear in both Jekyll site (`_publications/`) and React app (`src/public/publications.json`)
+
+## Key Files
+
+- `_config.yml`: Jekyll site configuration including navigation
+- `src/package.json`: React app dependencies and build scripts
+- `publications.json`: Shared publication data for React app
+- `pentexoire.json`: Profile/contact information for React app


### PR DESCRIPTION
Hi Prof. Long!
Saw your [post](https://www.linkedin.com/posts/darrell-d-e-long_404-not-found-activity-7332569923275132929-zSAk?utm_source=share&utm_medium=member_desktop&rcm=ACoAAC9BEjcBgWls2nNVcaRrpmBbzGSvOY_pwVw) about trying to make a space invaders game with AI and thought to try prompting it myself to do it. This PR is, essentially, what it was able to do with 2 prompts. The text of the prompts is below:

```
there's a 404.html page that currently has a pong game playing. Instead of pong, I want to have a functional version of space invaders that user can play after they hit "Enter" key to be displayed on this page. Please think about the necessary steps to create such game and give me a step-by-step todo list for implementation of this feature

Please go ahead and implement this

That's a good start! I'd like to make it look more like the original game, though, and make it a bit harder with more bullets flying around and the occasional ufo flying across the screen, like in the original game
```

This is what it was able to do:
![Screenshot From 2025-06-12 21-47-00](https://github.com/user-attachments/assets/8df94c16-31af-4e6a-bee8-21185d50c11d)

Not sure what your requirements for a proper space invaders game are, but looks pretty close to me.

Message below (as the rest of this PR) was AI generated:
Replaced the old Pong-style mini-game on the 404.html page with a retro-inspired Space Invaders clone. The new game features player movement, shooting, multiple invader types, UFO bonus, levels, lives, score tracking, and particle effects. Instructions and UI are included. This enhances the user experience for lost visitors with a more engaging and nostalgic mini-game.